### PR TITLE
New connections enabled by default.

### DIFF
--- a/pipe_dream.lua
+++ b/pipe_dream.lua
@@ -714,7 +714,7 @@ local function _connections_edit_impl(connection_data)
     filter_list = {},
     filter_mode = "blacklist",
     mode = "1234",
-    moving = false, -- New connections will be disabled by default
+    moving = true, -- New connections are enabled by default.
     id = os.epoch("utc")
   }
   local editing_con = false


### PR DESCRIPTION
A point of confusion is that connections are disabled by default, we should have them enabled by default instead.